### PR TITLE
integra backend com API ViaCEP e expõe endpoint GET /viacep/{cep}

### DIFF
--- a/backend/src/main/java/com/desafio/backend/controller/ViaCepController.java
+++ b/backend/src/main/java/com/desafio/backend/controller/ViaCepController.java
@@ -1,0 +1,30 @@
+package com.desafio.backend.controller;
+
+import com.desafio.backend.service.ViaCepService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/viacep")
+@CrossOrigin(origins = "*")
+public class ViaCepController {
+
+    private final ViaCepService viaCepService;
+
+    public ViaCepController(ViaCepService viaCepService) {
+        this.viaCepService = viaCepService;
+    }
+
+    @GetMapping("/{cep}")
+    public ResponseEntity<Map<String, String>> buscarEndereco(@PathVariable String cep) {
+        Map<String, String> endereco = viaCepService.buscarEnderecoPorCep(cep);
+
+        if (endereco.containsKey("erro")) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(endereco);
+    }
+}

--- a/backend/src/main/java/com/desafio/backend/service/ViaCepService.java
+++ b/backend/src/main/java/com/desafio/backend/service/ViaCepService.java
@@ -1,0 +1,21 @@
+package com.desafio.backend.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Map;
+
+@Service
+public class ViaCepService {
+
+    @SuppressWarnings("unchecked")
+    public Map<String, String> buscarEnderecoPorCep(String cep) {
+        String url = UriComponentsBuilder
+                .fromUriString("https://viacep.com.br/ws/" + cep + "/json/")
+                .toUriString();
+
+        RestTemplate restTemplate = new RestTemplate();
+        return restTemplate.getForObject(url, Map.class);
+    }
+}


### PR DESCRIPTION
Este PR adiciona a integração direta com a API pública do ViaCEP através de um endpoint no backend (GET /viacep/{cep}). Isto também permite que o frontend eventualmente recupere os dados de endereço diretamente pelo servidor.
Até aqui, todos os testes foram feitos via Postman.